### PR TITLE
added colors for activeGuide and gitGutter

### DIFF
--- a/lodestone.tmTheme
+++ b/lodestone.tmTheme
@@ -25,6 +25,12 @@
 				<string>#3E3D32</string>
 				<key>selection</key>
 				<string>#49483E</string>
+				<key>guide</key>
+				<string>#CCCCCC</string>
+				<key>activeGuide</key>
+				<string>#B7E388</string>
+				<key>stackGuide</key>
+				<string>#CCCCCC</string>
 			</dict>
 		</dict>
 		<dict>
@@ -280,6 +286,61 @@
 				<string>#AE81FF</string>
 				<key>foreground</key>
 				<string>#F8F8F0</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter deleted</string>
+			<key>scope</key>
+			<string>markup.deleted.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#F92672</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter inserted</string>
+			<key>scope</key>
+			<string>markup.inserted.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#A6E22E</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter changed</string>
+			<key>scope</key>
+			<string>markup.changed.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#967EFB</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter ignored</string>
+			<key>scope</key>
+			<string>markup.ignored.git_gutter</string>
+			<key>settings</key>
+			<dict>
+			<key>foreground</key>
+				<string>#565656</string>
+				</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter untracked</string>
+			<key>scope</key>
+			<string>markup.untracked.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#565656</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
Only in Sublime, wouldn't know if this would be helpful.
- added colors for activeGuide so the user would be easier to view the current indent.
- added colors for [gitgutter](https://github.com/jisaacks/GitGutter)
